### PR TITLE
Add keyFilter functionality with documentation and examples

### DIFF
--- a/Example/Example/Example/ContentView.swift
+++ b/Example/Example/Example/ContentView.swift
@@ -5,10 +5,30 @@ struct ContentView: View {
     var body: some View {
         NavigationView {
             List {
-                Section {
+                Section("Basic Usage") {
                     NavigationLink("UserDefaultsEditor") {
                         UserDefaultsEditor(
                             userDefaults: .standard,
+                            presentationStyle: .push
+                        )
+                    }
+                }
+                Section("With Key Filter") {
+                    NavigationLink("Custom Keys Only") {
+                        UserDefaultsEditor(
+                            userDefaults: .standard,
+                            keyFilter: { key in 
+                                key.contains("Key") || key.hasPrefix("app")
+                            },
+                            presentationStyle: .push
+                        )
+                    }
+                    NavigationLink("System Keys Only") {
+                        UserDefaultsEditor(
+                            userDefaults: .standard,
+                            keyFilter: { key in 
+                                key.hasPrefix("NS") || key.hasPrefix("Apple") || key.hasPrefix("com.apple")
+                            },
                             presentationStyle: .push
                         )
                     }

--- a/README.md
+++ b/README.md
@@ -16,3 +16,26 @@ UserDefaultsEditor(
     presentationStyle: .push // or .modal
 )
 ```
+
+## Key Filtering
+You can filter which keys are displayed using the `keyFilter` parameter. This is useful for debugging specific parts of your app or hiding sensitive data.
+
+```Swift
+// Only show keys that start with "app"
+UserDefaultsEditor(
+    userDefaults: .standard,
+    keyFilter: { key in key.hasPrefix("app") },
+    presentationStyle: .push
+)
+
+// Hide system keys and only show custom keys
+UserDefaultsEditor(
+    userDefaults: .standard,
+    keyFilter: { key in 
+        !key.hasPrefix("NS") && 
+        !key.hasPrefix("Apple") && 
+        !key.hasPrefix("com.apple")
+    },
+    presentationStyle: .modal
+)
+```

--- a/Sources/UserDefaultsEditor/UserDefaultsEditor.swift
+++ b/Sources/UserDefaultsEditor/UserDefaultsEditor.swift
@@ -38,6 +38,7 @@ public struct UserDefaultsEditor: View {
     /// Initializes a `UserDefaultsEditor` view with the specified presentation style and UserDefaults source.
     /// - Parameters:
     ///   - userDefaults: The UserDefaults instance to edit.
+    ///   - keyFilter: An optional closure to filter which keys are displayed. If provided, only keys for which this closure returns `true` will be shown.
     ///   - presentationStyle: The presentation style for the editor (default is `.push`).
     public init(
         userDefaults: UserDefaults,

--- a/Sources/UserDefaultsEditor/UserDefaultsEditor.swift
+++ b/Sources/UserDefaultsEditor/UserDefaultsEditor.swift
@@ -14,12 +14,18 @@ public struct UserDefaultsEditor: View {
     @State var searchQuery: String = ""
 
     var filteredValues: [UserDefaultsRepresentation] {
-        if searchQuery.isEmpty {
+        let temp = if searchQuery.isEmpty {
             allValues
         } else {
             allValues.filter {
                 $0.key.lowercased().range(of: searchQuery.lowercased()) != nil
             }
+        }
+
+        if let keyFilter {
+            return temp.filter { keyFilter($0.key) }
+        } else {
+            return temp
         }
     }
 
@@ -27,6 +33,7 @@ public struct UserDefaultsEditor: View {
     let dataSource: () -> [String: Any]
     let write: (_ key: String, _ newValue: Any) -> Void
     let remove: (_ key: String) -> Void
+    let keyFilter: ((String) -> Bool)?
 
     /// Initializes a `UserDefaultsEditor` view with the specified presentation style and UserDefaults source.
     /// - Parameters:
@@ -34,10 +41,12 @@ public struct UserDefaultsEditor: View {
     ///   - presentationStyle: The presentation style for the editor (default is `.push`).
     public init(
         userDefaults: UserDefaults,
+        keyFilter: ((String) -> Bool)? = nil,
         presentationStyle: PresentationStyle = .push
     ) {
         self.init(
             presentationStyle: presentationStyle,
+            keyFilter: keyFilter,
             dictionary: userDefaults.dictionaryRepresentation(),
             write: { userDefaults.set($1, forKey: $0) },
             remove: { userDefaults.removeObject(forKey: $0) }
@@ -46,6 +55,7 @@ public struct UserDefaultsEditor: View {
 
     fileprivate init(
         presentationStyle: PresentationStyle,
+        keyFilter: ((String) -> Bool)? = nil,
         dictionary: @escaping @autoclosure () -> [String: Any],
         write: @escaping (_ key: String, _ newValue: Any) -> Void,
         remove: @escaping (_ key: String) -> Void
@@ -54,6 +64,7 @@ public struct UserDefaultsEditor: View {
         self._allValues = .init(initialValue: allValues)
         self.write = write
         self.presentationStyle = presentationStyle
+        self.keyFilter = keyFilter
         self.remove = remove
         self.dataSource = dictionary
     }


### PR DESCRIPTION
Complete implementation of keyFilter functionality for UserDefaultsEditor with proper documentation and examples.

Changes:
Added keyFilter parameter to UserDefaultsEditor initializers
Implemented filtering logic in filteredValues computed property
Added parameter documentation for keyFilter in public API
Enhanced README with Key Filtering section and usage examples
Updated demo app with interactive keyFilter examples
